### PR TITLE
changed consent handling + disableBrowserFeatureDetection

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -832,11 +832,6 @@ if (data.useCookieConsent == true || data.useGoogleConsentAPI == true) {
 // Option to set allow CookieConsent
 let useRememberCookieConsentGiven = data.useRememberCookieConsentGiven;
 let useCookieConsentGiven = data.useCookieConsentGiven;
-
-log('Consent Stuff: isConsentGranted - ' + isConsentGranted('analytics_storage'));
-log('Consent Stuff: useRememberCookieConsentGiven - ' + useRememberCookieConsentGiven);
-
-
 if (((data.useGoogleConsentAPI == true) && isConsentGranted('analytics_storage')) || useRememberCookieConsentGiven == true || useRememberCookieConsentGiven == "true") {
   _matomo(['rememberCookieConsentGiven']);
     log('Matomo Analytics Remember Cookie.');

--- a/template.tpl
+++ b/template.tpl
@@ -689,6 +689,25 @@ ___TEMPLATE_PARAMETERS___
             "help": "Should be true or false"
           }
         ]
+      },
+      {
+        "type": "SELECT",
+        "name": "disableBrowserFeatureDetection",
+        "displayName": "Disable Browser Feature Detection",
+        "macrosInSelect": true,
+        "selectItems": [
+          {
+            "value": true,
+            "displayValue": "true"
+          },
+          {
+            "value": false,
+            "displayValue": "false"
+          }
+        ],
+        "simpleValueType": true,
+        "help": "When this option is set to \"true\", no browser features are being accessed, and they also aren’t used to create the short-lived identifier (similar to a fingerprint). The browser resolution will be also no longer tracked and won’t appear in your reports in Matomo any more. Activate when tracking without consent to comply with TTDSG (Germany’s ePrivacy implementation).",
+        "defaultValue": false
       }
     ]
   },
@@ -773,6 +792,13 @@ if (data.useCookies == false) {
   _matomo(['disableCookies']);
   log('disable Matomo Analytics Cookie.');
 }
+
+// Disable browser feature detection
+if (data.disableBrowserFeatureDetection == true) {
+  _matomo(['disableBrowserFeatureDetection']);
+  log('Disabled browser feature detection.');
+}
+
 
 // Set secure cookie
 if (data.setSecureCookie == true) {

--- a/template.tpl
+++ b/template.tpl
@@ -799,7 +799,6 @@ if (data.disableBrowserFeatureDetection == true) {
   log('Disabled browser feature detection.');
 }
 
-
 // Set secure cookie
 if (data.setSecureCookie == true) {
   _matomo(['setSecureCookie', 1]);
@@ -833,7 +832,12 @@ if (data.useCookieConsent == true || data.useGoogleConsentAPI == true) {
 // Option to set allow CookieConsent
 let useRememberCookieConsentGiven = data.useRememberCookieConsentGiven;
 let useCookieConsentGiven = data.useCookieConsentGiven;
-if (isConsentGranted('analytics_storage') || useRememberCookieConsentGiven == true || useRememberCookieConsentGiven == "true") {
+
+log('Consent Stuff: isConsentGranted - ' + isConsentGranted('analytics_storage'));
+log('Consent Stuff: useRememberCookieConsentGiven - ' + useRememberCookieConsentGiven);
+
+
+if (((data.useGoogleConsentAPI == true) && isConsentGranted('analytics_storage')) || useRememberCookieConsentGiven == true || useRememberCookieConsentGiven == "true") {
   _matomo(['rememberCookieConsentGiven']);
     log('Matomo Analytics Remember Cookie.');
 


### PR DESCRIPTION
If there is no Google Consent Mode initialization at all in place (which is the usual setup if one decides against Google tagging and instead wants to use Matomo; maybe without any consent promt), the template API call `"isConsentGranted('analytics_storage')"` will always return "_true_". 

This may become a problem because "_rememberCookieConsentGiven_" will always be executed in such setups with the current template code. This results in an unwanted `mtm_cookie_consent` cookie. 

It might be a solution to bind the usage of the Google Consent Mode state for setting the _rememberCookieConsentGiven_ option to the useGoogleConsentAPI setting: 

``` 
if (((data.useGoogleConsentAPI == true) && isConsentGranted('analytics_storage')) || 
useRememberCookieConsentGiven == true || useRememberCookieConsentGiven == "true") {... 
```

This would allow settings like "_disableBrowserFeatureDetection_" to work, too. Without "dismantling" the Consent API, "_rememberCookieConsentGiven_" overrides the option (I added in my forked version as well) and plugins and resolution will always be part of the data capturing in the browser (problematic in Germany due to TTDSG).  

Both changes are part of this pull request. If you can think of a better way to prevent the `mtm_cookie_consent` from being created in a "consent free" setup, just merge the first change. ;)    